### PR TITLE
Centos 8: os-release symlink already exists

### DIFF
--- a/images/centos/8/Dockerfile
+++ b/images/centos/8/Dockerfile
@@ -22,6 +22,5 @@ RUN yum -y swap coreutils-single coreutils && \
 RUN rm /extra-packages /missing-docs
 
 RUN echo VARIANT_ID=container >> /etc/os-release
-RUN ln -s /etc/os-release /usr/lib/os-release
 
 CMD /bin/sh


### PR DESCRIPTION
STEP 12: RUN ln -s /etc/os-release /usr/lib/os-release
ln: failed to create symbolic link '/usr/lib/os-release': File exists