### PR TITLE
Centos 7: os-release symlink already exists

### DIFF
--- a/images/centos/7/Dockerfile
+++ b/images/centos/7/Dockerfile
@@ -25,6 +25,5 @@ RUN rm /missing-docs
 RUN rm /extra-packages
 
 RUN echo VARIANT_ID=container >> /etc/os-release
-RUN ln -s /etc/os-release /usr/lib/os-release
 
 CMD /bin/sh


### PR DESCRIPTION
STEP 12: RUN ln -s /etc/os-release /usr/lib/os-release
ln: failed to create symbolic link '/usr/lib/os-release': File exists